### PR TITLE
Fix downloads where episode GUID contains "/"

### DIFF
--- a/src/podcast.rs
+++ b/src/podcast.rs
@@ -295,7 +295,7 @@ impl Podcast {
     pub async fn download_episode<'a>(&self, episode: Episode<'a>) -> DownloadedEpisode<'a> {
         let partial_path = {
             let file_name = format!("{}.partial", episode.guid);
-            self.download_folder().join(file_name)
+            self.download_folder().join(file_name.replace("/", "-"))
         };
 
         let mut downloaded: u64 = 0;


### PR DESCRIPTION
If the episode GUID contains "/", the download folder will not have been created, and a file or directory not found error will occur.