### PR TITLE
Update Cargo.toml link to repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.29"
 edition = "2021"
 description = "Simple CLI podcatcher"
 license = "MIT"
+repository = "https://github.com/TBS1996/TaleCast"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
to allow https://crates.io/  https://lib.rs/ and https://rust-digger.code-maven.com/ to link to it