### PR TITLE
fix: PodcastConfigs::loads exists when the config is empty

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -467,7 +467,6 @@ impl PodcastConfigs {
                 "*  Manually configuring the {:?} file.",
                 &PodcastConfigs::path()
             );
-            std::process::exit(1);
         }
 
         PodcastConfigs(map)


### PR DESCRIPTION
All code branches that operates on PodcastConfigs are happy if it's empty, except the `load` function that called `std::process::exit(1)`.

Both `add` and `search` tries to push entry to the `PodcastConfigs` map, but as `push` tries to `load` (100% logical to prevent data loss) it existed when the config was empty. As a result we couldn't add new entries until we added an entry manually (which is a bit tricky as the format is documented and shouldn't be an expected behaviour to add entries manually before a user can use `--add` or `--search`.