### PR TITLE
Support for max_episodes when using Backlog Mode. 

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -482,6 +482,7 @@ pub enum DownloadMode {
     Backlog {
         start: Unix,
         interval: Unix,
+        max_episodes: Option<i64>,
     },
 }
 
@@ -519,16 +520,6 @@ impl DownloadMode {
                 std::process::exit(1);
             }
             (Some(start), Some(interval)) => {
-                if podcast_config.max_days.is_enabled() {
-                    eprintln!("'max_days' not compatible with backlog mode.");
-                    std::process::exit(1);
-                }
-
-                if podcast_config.max_episodes.is_enabled() {
-                    eprintln!("'max_episodes' not compatible with backlog mode.");
-                    eprintln!("If you want to limit the amount of episodes to download, consider changing the 'backlog_start' setting.");
-                    std::process::exit(1);
-                }
 
                 if podcast_config.earliest_date.is_enabled() {
                     eprintln!("'earliest_date' not compatible with backlog mode.");
@@ -543,6 +534,9 @@ impl DownloadMode {
                 DownloadMode::Backlog {
                     start: std::time::Duration::from_secs(start.timestamp() as u64),
                     interval: Unix::from_secs(interval as u64 * 86400),
+                    max_episodes: podcast_config
+                    .max_episodes
+                    .into_val(global_config.max_episodes.as_ref()),
                 }
             }
         }

--- a/src/episode.rs
+++ b/src/episode.rs
@@ -201,9 +201,11 @@ impl Episode {
         DownloadedEpisodes::load(&path).contains_episode(&id)
     }
 
-    pub fn should_download(&self, mode: &DownloadMode, episode_qty: usize) -> bool {
+    pub fn within_age_limits(&self, mode: &DownloadMode, episode_qty: usize) -> bool {
         let passed_filter = match mode {
-            DownloadMode::Backlog { start, interval } => {
+            
+            DownloadMode::Backlog { start, interval, max_episodes: _ } => {
+                
                 let time_passed = utils::current_unix() - *start;
                 let intervals_passed = time_passed.as_secs() / interval.as_secs();
                 intervals_passed >= self.index as u64
@@ -211,25 +213,22 @@ impl Episode {
 
             DownloadMode::Standard {
                 max_time,
-                max_episodes,
+                max_episodes: _,
                 earliest_date,
             } => {
                 let max_time_exceeded = max_time.map_or(false, |max_time| {
                     (utils::current_unix() - self.attrs.published) > max_time
                 });
 
-                let max_episodes_exceeded = max_episodes.map_or(false, |max_episodes| {
-                    (episode_qty - max_episodes as usize) > self.index
-                });
-
                 let episode_too_old =
                     earliest_date.map_or(false, |date| date > self.attrs.published);
 
-                !max_time_exceeded && !max_episodes_exceeded && !episode_too_old
+                !max_time_exceeded && !episode_too_old
             }
         };
 
         passed_filter && !self.is_downloaded()
+
     }
 
     /// Filename of episode when it's being downloaded.

--- a/src/podcast.rs
+++ b/src/podcast.rs
@@ -222,18 +222,26 @@ impl Podcast {
         let mut pending: Vec<&Episode> = self
             .episodes
             .iter()
-            .filter(|episode| episode.should_download(&self.mode, qty))
+            .filter(|episode| episode.within_age_limits(&self.mode, qty))
             .collect();
-
+        
         // In backlog mode it makes more sense to download earliest episode first.
         // in standard mode, the most recent episodes are more relevant.
         match self.mode {
-            DownloadMode::Backlog { .. } => {
+            
+            DownloadMode::Backlog { start: _, interval: _,max_episodes} => {
                 pending.sort_by_key(|ep| ep.index);
+                if max_episodes.is_some() { 
+                    pending.truncate(max_episodes.unwrap() as usize);
+                }
             }
-            DownloadMode::Standard { .. } => {
+
+            DownloadMode::Standard { max_time: _, earliest_date: _, max_episodes } => {
                 pending.sort_by_key(|ep| ep.index);
                 pending.reverse();
+                if max_episodes.is_some() { 
+                    pending.truncate(max_episodes.unwrap() as usize);
+                }
             }
         }
 


### PR DESCRIPTION
Added support for `max_episodes` when using Backlog Mode.  This is useful when you have a podcast channel with hundreds or thousands of old episodes and you want to listen to them in Chronological order without downloading all of the episodes.  For example, if you want to listen to the podcast "Six Minutes" in chronological order, the existing Backlog Mode will download all the episodes immediately.  With this commit, if `max_episodes = 4`, then only the first four episodes are downloaded and the next four next time Talecast is run.